### PR TITLE
Pin highline gem version

### DIFF
--- a/i18n-tasks.gemspec
+++ b/i18n-tasks.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', '>= 4.0.2'
   s.add_dependency 'ast', '>= 2.1.0'
   s.add_dependency 'erubi'
-  s.add_dependency 'highline', '>= 2.0.0'
+  s.add_dependency 'highline', '~> 2.1.0'
   s.add_dependency 'i18n'
   s.add_dependency 'parser', '>= 3.2.2.1'
   s.add_dependency 'rails-i18n'


### PR DESCRIPTION
Pin highline gem version to 2.1.0 so we can install it with ruby 2.7.8 when required by the logikcull app